### PR TITLE
fix(README): replace travis ci build badge with correct one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Logstash Plugin
 
-[![Travis Build Status](https://travis-ci.org/logstash-plugins/logstash-codec-json_lines.svg)](https://travis-ci.org/logstash-plugins/logstash-codec-json_lines)
+[![Travis Build Status](https://travis-ci.org/cherweg/logstash-codec-json_stream.svg?branch=master)](https://travis-ci.org/cherweg/logstash-codec-json_stream)
 
 This is a plugin for [Logstash](https://github.com/elastic/logstash).
 


### PR DESCRIPTION
The link to the travis build was linking to another travis page. This commit fixes the link.